### PR TITLE
change order of output formats in `_output.yml`

### DIFF
--- a/_output.yml
+++ b/_output.yml
@@ -1,3 +1,9 @@
+bookdown::pdf_book:
+  includes:
+    in_header: preamble.tex
+  latex_engine: xelatex
+  citation_package: natbib
+bookdown::epub_book: default
 bookdown::gitbook:
   css: style.css
   config:
@@ -8,9 +14,3 @@ bookdown::gitbook:
         <li><a href="https://github.com/rstudio/bookdown" target="blank">Published with bookdown</a></li>
     edit:
       link: https://github.com/rstudio/bookdown-demo/edit/master/%s
-bookdown::pdf_book:
-  includes:
-    in_header: preamble.tex
-  latex_engine: xelatex
-  citation_package: natbib
-bookdown::epub_book: default


### PR DESCRIPTION
In order to guarantee that the menu item and links to downloadable pdf and epub appear in
the html output on first build.

See https://github.com/rstudio/bookdown/issues/210.