### PR TITLE
Exit _build.sh with error when any of it's subtasks fail

### DIFF
--- a/_build.sh
+++ b/_build.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -ev
+
 Rscript -e "bookdown::render_book('index.Rmd', 'bookdown::gitbook')"
 Rscript -e "bookdown::render_book('index.Rmd', 'bookdown::pdf_book')"
 Rscript -e "bookdown::render_book('index.Rmd', 'bookdown::epub_book')"


### PR DESCRIPTION
`set -ev` prints every command executed and fails the entire script when
any command fails. This prevents false-positive cases where only one of
the tasks fails. For instance when there are LaTeX specific errors which
only cause the `bookdown::pdf_book` script to fail. In this case Travis still
marks a pull request as if the build passes.