### PR TITLE
Add now.json and Dockerfile for building HTML book and deploy to now.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM conoria/alpine-r-bookdown
+
+WORKDIR /usr/src
+
+COPY . .
+
+RUN R -q -e 'bookdown::render_book("index.Rmd", "bookdown::gitbook")' && mv _book /public

--- a/now.json
+++ b/now.json
@@ -1,0 +1,4 @@
+{
+  "type": "static",
+  "public": true
+}


### PR DESCRIPTION
This PR offers a different deployment method via now.sh (Ref #35)

To deploy with Now, follow instructions from https://zeit.co/now to install now CLI first.

```bash
$ cd bookdown-demo
$ now
```